### PR TITLE
TOOLS-13 Fix Travis build: run tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
 
+script:
+    - make test
+
 after_success:
     - test -n "$TRAVIS_TAG" && make release

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
+test:
+	./script/test
+
 release:
 	curl -sL https://git.io/goreleaser | bash

--- a/script/test
+++ b/script/test
@@ -2,4 +2,4 @@
 set -e
 packages=$(go list ./... | grep -v /vendor/)
 echo $packages | xargs go vet
-echo $packages | xargs go test -tags=$TEST_TAGS -v
+echo $packages | xargs go test -v

--- a/script/test
+++ b/script/test
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+packages=$(go list ./... | grep -v /vendor/)
+echo $packages | xargs go vet
+echo $packages | xargs go test -tags=$TEST_TAGS -v


### PR DESCRIPTION
After #1, Travis always executed `make` which is the default in Go projects that have a `Makefile`.
With this change, we explicitely run `go test` and `go vet`.