### PR TITLE
WL-620 adapt release binary structure to previous standard

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,19 +1,14 @@
+archives:
+  - format: binary
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 builds:
   - env:
       - CGO_ENABLED=0
     goos:
       - linux
       - darwin
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      386: i386
-      amd64: x86_64
 checksum:
-  name_template: 'checksums.txt'
-snapshot:
-  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+  name_template: 'github-team-ssh-keys_checksums.txt'
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
In commit c96f090 (fix goreleaser format, 2021-05-18) we added some
values that changed the filenames of the release.

- [x] Tested with jenkins staging using this PR: https://github.com/Jimdo/jenkins/pull/1788